### PR TITLE
Change receipt email text to match user expectations

### DIFF
--- a/notifs/tejo/aksopay-receipt/email/notif.txt
+++ b/notifs/tejo/aksopay-receipt/email/notif.txt
@@ -1,6 +1,6 @@
 Estimata{{#if intent.customer_name}} {{intent.customer_name}}{{/if}},
 
-Koran dankon pro via {{#if isDonation}}donaco{{else}}mendo{{/if}}.
+Koran dankon pro via pago.
 
 
 ---


### PR DESCRIPTION
Users frequently misunderstood the mail text. It didn't sound like a receipt, but like a request for payment, while in fact this mail is sent after a payment has been confirmed.